### PR TITLE
Use FromStr in default parser

### DIFF
--- a/src/fields_parse.rs
+++ b/src/fields_parse.rs
@@ -71,8 +71,9 @@ fn create_parser<'a>(
     count_args: usize,
 ) -> quote::__private::TokenStream {
     let function_to_parse = match parser_type {
-        ParserType::Default => match types.next() {
-            Some(ty) => {
+        ParserType::Default => match count_args {
+            1 => {
+                let ty = types.next().expect("count_args != types.len()");
                 quote! { (|s: String| {
                     let res = <#ty>::from_str(&s)
                         .map_err(|e|ParseError::IncorrectFormat({ let e: Box<dyn std::error::Error + Send + Sync + 'static> = e.into(); e }))?;
@@ -80,7 +81,7 @@ fn create_parser<'a>(
                  })
                 }
             }
-            None => quote! { compile_error!("Expected 1 argument") },
+            _ => quote! { compile_error!("Expected exactly 1 argument") },
         },
         ParserType::Split { separator } => parser_with_separator(
             &separator.clone().unwrap_or_else(|| " ".to_owned()),

--- a/src/fields_parse.rs
+++ b/src/fields_parse.rs
@@ -67,15 +67,20 @@ pub fn impl_parse_args_named(
 
 fn create_parser<'a>(
     parser_type: &ParserType,
-    types: impl Iterator<Item = &'a Type>,
+    mut types: impl Iterator<Item = &'a Type>,
     count_args: usize,
 ) -> quote::__private::TokenStream {
     let function_to_parse = match parser_type {
-        ParserType::Default => match count_args {
-            1 => {
-                quote! { (|s: String| Ok((s,))) }
+        ParserType::Default => match types.next() {
+            Some(ty) => {
+                quote! { (|s: String| {
+                    let res = <#ty>::from_str(&s)
+                        .map_err(|e|ParseError::IncorrectFormat({ let e: Box<dyn std::error::Error + Send + Sync + 'static> = e.into(); e }))?;
+                    Ok((res, ))
+                 })
+                }
             }
-            _ => quote! { compile_error!("Expected 1 argument") },
+            None => quote! { compile_error!("Expected 1 argument") },
         },
         ParserType::Split { separator } => parser_with_separator(
             &separator.clone().unwrap_or_else(|| " ".to_owned()),


### PR DESCRIPTION
This fixes issue #8 .
Currently, parsing will fail if there is excess whitespace around the value to parse. Eg. `/start 5 ` will not parse for `start: u8`. This is in line with the implementation of the split macro, however it might be nice to allow leading and trailing whitespace and simply [trim](https://doc.rust-lang.org/stable/std/primitive.str.html#method.trim) the input before calling `from_str`.