### PR TITLE
Fix generic type handling

### DIFF
--- a/src/fields_parse.rs
+++ b/src/fields_parse.rs
@@ -106,7 +106,7 @@ fn parser_with_separator<'a>(
     let inner = quote! { let mut splited = s.split(#separator); };
     let i = 0..count_args;
     let inner2 = quote! {
-        #(#types::from_str(splited.next().ok_or(ParseError::TooFewArguments {
+        #(<#types>::from_str(splited.next().ok_or(ParseError::TooFewArguments {
             expected: #count_args,
             found: #i,
             message: format!("Expected but not found arg number {}", #i + 1),


### PR DESCRIPTION
Fix syntax error in generated code when generic type is used with `parse_with = "split"`.

```rust
#[derive(BotCommand)]
#[command(rename = "lowercase", parse_with = "split")]
enum Foo {
    Bar { targets: My<String> },
}
```