### PR TITLE
feat: support more rename rules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod command_enum;
 mod dialogue_state;
 mod fields_parse;
 mod rename_rules;
+mod parts;
 
 extern crate proc_macro;
 extern crate quote;

--- a/src/parts.rs
+++ b/src/parts.rs
@@ -1,0 +1,149 @@
+/// Parts: Split the input to tokens with the common naming conventions.
+
+use std::{borrow::Cow, ops::Deref};
+
+#[derive(Debug, PartialEq)]
+pub struct Parts(Vec<String>);
+
+impl Parts {
+    pub fn to_pascalcase(&self) -> String {
+        self.iter().fold(String::new(), |mut acc, token| {
+            for (idx, c) in token.chars().enumerate() {
+                if idx == 0 {
+                    acc.push(c.to_ascii_uppercase());
+                } else {
+                    acc.push(c);
+                }
+            }
+            acc
+        })
+    }
+
+    pub fn to_camelcase(&self) -> String {
+        self.iter().enumerate().fold(String::new(), |mut acc, (token_idx, token)| {
+            for (c_idx, c) in token.chars().enumerate() {
+                if token_idx != 0 && c_idx == 0 {
+                    acc.push(c.to_ascii_uppercase());
+                } else {
+                    acc.push(c);
+                }
+            }
+            acc
+        })
+    }
+
+    pub fn to_snakecase(&self) -> String {
+        self.join("_")
+    }
+
+    pub fn to_kebabcase(&self) -> String {
+        self.join("-")
+    }
+
+    pub fn to_screaming_snakecase(&self) -> String {
+        self.iter().map(|s| s.to_uppercase()).collect::<Vec<String>>().join("_")
+    }
+
+    pub fn to_screaming_kebabcase(&self) -> String {
+        self.iter().map(|s| s.to_uppercase()).collect::<Vec<String>>().join("-")
+    }
+}
+
+impl Deref for Parts {
+    type Target = Vec<String>;
+
+    fn deref(&self) -> &Vec<String> {
+        &self.0
+    }
+}
+
+impl From<&str> for Parts {
+    fn from(input: &str) -> Self {
+        let mut input = Cow::Borrowed(input);
+        let mut parts = Vec::new();
+        let mut buf: String = String::new();
+        
+        // If the input contains with '_' or '-', we convert
+        // all the character in `input` to lowercase so it can split correctly.
+        //
+        // For example, passing "HelLo_WoRld" will get ["hello", "world"].
+        if input.contains('_') || input.contains('-') {
+            input = Cow::Owned(input.to_ascii_lowercase());
+        }
+        
+        // If the input is all uppercase,
+        // we returns a vector with only the lowercased input.
+        //
+        // For example, passing "HELLOWORLD" will get ["helloworld"].
+        if input.chars().all(|c| c.is_ascii_uppercase()) {
+            return Parts(vec![input.to_ascii_lowercase()]);
+        }
+        
+        // Separate the flush part as macro.
+        //
+        // We don't write this in closure, as closure will take
+        // the mutable reference of `parts` and `buf`,
+        // which is not expected.
+        macro_rules! flush {
+            () => {
+                if !buf.is_empty() {
+                    parts.push(buf.clone());
+                    buf.clear();
+                }
+            };
+        }
+        
+        for c in input.chars() {
+            if matches!(c, '_' | '-') {
+                // If we saw '_' or '-', we flush the buffer. For example:
+                //
+                // buf
+                // ~~~~~v [flush point]
+                // hello_world
+                //       ~~~~~ next buf
+                flush!();
+            } else if c.is_ascii_uppercase() {
+                // If we saw an uppercase character (which will appear if
+                // the `input` is named with PascalCase or camelCase),
+                // we flush the buffer. For example:
+                //
+                // buf
+                // ~~~~~v [flush point]
+                // HelloWorld
+                //      ~~~~~ next buf (all lowercased)
+                flush!();
+                buf.push(c.to_ascii_lowercase());
+            } else {
+                // Otherwise, we push to buf.
+                buf.push(c);
+            }
+        }
+        
+        // Flush the buffer eventually.
+        parts.push(buf);
+        // Construct `Parts`.
+        Parts(parts)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Parts;
+
+    #[test]
+    fn test_parts_from_str() {
+        let expected = ["hello", "world"];
+
+        assert_eq!(*Parts::from("HelloWorld"), &expected[..]);
+        assert_eq!(*Parts::from("helloWorld"), &expected[..]);
+        assert_eq!(*Parts::from("HELLOWORLD"), ["helloworld"].as_slice());
+        assert_eq!(*Parts::from("helloworld"), ["helloworld"].as_slice());
+        assert_eq!(*Parts::from("HelLo_WoRld"), &expected[..]);
+        assert_eq!(*Parts::from("hello_world"), &expected[..]);
+        assert_eq!(*Parts::from("HELLO_WORLD"), &expected[..]);
+        assert_eq!(*Parts::from("Hello_World"), &expected[..]);
+        assert_eq!(*Parts::from("hello-world"), &expected[..]);
+        assert_eq!(*Parts::from("HELLO-WORLD"), &expected[..]);
+        assert_eq!(*Parts::from("Hello-World"), &expected[..]);
+    }
+}

--- a/src/parts.rs
+++ b/src/parts.rs
@@ -1,4 +1,4 @@
-/// Parts: Split the input to tokens with the common naming conventions.
+//! Parts: Split the input to tokens with the common naming conventions.
 
 use std::{borrow::Cow, ops::Deref};
 

--- a/src/parts.rs
+++ b/src/parts.rs
@@ -9,6 +9,10 @@ impl Parts {
     pub fn to_pascalcase(&self) -> String {
         self.iter().fold(String::new(), |mut acc, token| {
             for (idx, c) in token.chars().enumerate() {
+                // We convert the first character of token to uppercase,
+                // then the rest to lowercase. As we've converted all the characters
+                // in token to lowercase (see From::<&str>::from), we just push those
+                // characters to `acc` with no any modification.
                 if idx == 0 {
                     acc.push(c.to_ascii_uppercase());
                 } else {
@@ -22,6 +26,11 @@ impl Parts {
     pub fn to_camelcase(&self) -> String {
         self.iter().enumerate().fold(String::new(), |mut acc, (token_idx, token)| {
             for (c_idx, c) in token.chars().enumerate() {
+                // If the token is not in the first order ("camel" in ["camel", "case"]),
+                // we convert the first character of token to uppercase (["camel", "Case"]), 
+                // then the rest to lowercase. As we've converted all the characters
+                // in token to lowercase (see From::<&str>::from), we just push those
+                // characters to `acc` with no any modification.
                 if token_idx != 0 && c_idx == 0 {
                     acc.push(c.to_ascii_uppercase());
                 } else {
@@ -41,10 +50,14 @@ impl Parts {
     }
 
     pub fn to_screaming_snakecase(&self) -> String {
+        // The logic is just like what to_snakecase() does,
+        // but we convert all the tokens to uppercase first.
         self.iter().map(|s| s.to_uppercase()).collect::<Vec<String>>().join("_")
     }
 
     pub fn to_screaming_kebabcase(&self) -> String {
+        // The logic is just like what to_kebabcase() does,
+        // but we convert all the tokens to uppercase first.
         self.iter().map(|s| s.to_uppercase()).collect::<Vec<String>>().join("-")
     }
 }

--- a/src/rename_rules.rs
+++ b/src/rename_rules.rs
@@ -1,6 +1,114 @@
+// Some concepts are from Serde.
+
+use crate::parts::Parts;
+
+/// Apply a renaming rule to an enum variant,
+/// returning the version expected in the source.
+///
+/// The possible `rule` can be: `lowercase`, `UPPERCASE`, `PascalCase`,
+/// `camelCase`, `snake_case`, `SCREAMING_SNAKE_CASE`, `kebab-case`,
+/// `SCREAMING-KEBAB-CASE`. See tests for the details how it will work.
 pub fn rename_by_rule(input: &str, rule: &str) -> String {
     match rule {
-        "lowercase" => input.to_string().to_lowercase(),
+        "lowercase" => input.to_lowercase(),
+        "UPPERCASE" => input.to_uppercase(),
+        "PascalCase" => Parts::from(input).to_pascalcase(),
+        "camelCase" => Parts::from(input).to_camelcase(),
+        "snake_case" => Parts::from(input).to_snakecase(),
+        "SCREAMING_SNAKE_CASE" => Parts::from(input).to_screaming_snakecase(),
+        "kebab-case" => Parts::from(input).to_kebabcase(),
+        "SCREAMING-KEBAB-CASE" => Parts::from(input).to_screaming_kebabcase(),
         _ => rule.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! test_eq {
+        ($lval:expr, $rval:expr) => {
+            assert_eq!(rename_by_rule($lval, TYPE), $rval);
+        };
+    }
+
+    #[test]
+    fn test_lowercase() {
+        const TYPE: &str = "lowercase";
+
+        test_eq!("HelloWorld", "helloworld");
+        test_eq!("Hello_World", "hello_world");
+        test_eq!("Hello-World", "hello-world");
+        test_eq!("helloWorld", "helloworld");
+    }
+
+    #[test]
+    fn test_uppercase() {
+        const TYPE: &str = "UPPERCASE";
+
+        test_eq!("HelloWorld", "HELLOWORLD");
+        test_eq!("Hello_World", "HELLO_WORLD");
+        test_eq!("Hello-World", "HELLO-WORLD");
+        test_eq!("helloWorld", "HELLOWORLD");
+    }
+
+    #[test]
+    fn test_pascalcase() {
+        const TYPE: &str = "PascalCase";
+
+        test_eq!("HelloWorld", "HelloWorld");
+        test_eq!("Hello_World", "HelloWorld");
+        test_eq!("Hello-World", "HelloWorld");
+        test_eq!("helloWorld", "HelloWorld");
+    }
+
+    #[test]
+    fn test_camelcase() {
+        const TYPE: &str = "camelCase";
+
+        test_eq!("HelloWorld", "helloWorld");
+        test_eq!("Hello_World", "helloWorld");
+        test_eq!("Hello-World", "helloWorld");
+        test_eq!("helloWorld", "helloWorld");
+    }
+
+    #[test]
+    fn test_snakecase() {
+        const TYPE: &str = "snake_case";
+
+        test_eq!("HelloWorld", "hello_world");
+        test_eq!("Hello_World", "hello_world");
+        test_eq!("Hello-World", "hello_world");
+        test_eq!("helloWorld", "hello_world");
+    }
+
+    #[test]
+    fn test_screaming_snakecase() {
+        const TYPE: &str = "SCREAMING_SNAKE_CASE";
+
+        test_eq!("HelloWorld", "HELLO_WORLD");
+        test_eq!("Hello_World", "HELLO_WORLD");
+        test_eq!("Hello-World", "HELLO_WORLD");
+        test_eq!("helloWorld", "HELLO_WORLD");
+    }
+
+    #[test]
+    fn test_kebabcase() {
+        const TYPE: &str = "kebab-case";
+
+        test_eq!("HelloWorld", "hello-world");
+        test_eq!("Hello_World", "hello-world");
+        test_eq!("Hello-World", "hello-world");
+        test_eq!("helloWorld", "hello-world");
+    }
+
+    #[test]
+    fn test_screaming_kebabcase() {
+        const TYPE: &str = "SCREAMING-KEBAB-CASE";
+
+        test_eq!("HelloWorld", "HELLO-WORLD");
+        test_eq!("Hello_World", "HELLO-WORLD");
+        test_eq!("Hello-World", "HELLO-WORLD");
+        test_eq!("helloWorld", "HELLO-WORLD");
     }
 }


### PR DESCRIPTION
This PR brings the `UPPERCASE`, `PascalCase`, `camelCase`, `snake_case`, `SCREAMING_SNAKE_CASE`, `kebab-case`, and `SCREAMING-KEBAB-CASE` rename rules. These cases are [those that Serde supports](https://serde.rs/container-attrs.html#rename_all).

The test coverage of this PR seems 100% already.