### PR TITLE
Fixed issue that you couldn't rename a particular command

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -38,7 +38,8 @@ impl Command {
         } else {
             "/"
         };
-        if let Some(rule) = &global_parameters.rename_rule {
+        if global_parameters.rename_rule.is_some() && !self.renamed {
+            let rule = global_parameters.rename_rule.as_ref().unwrap();
             String::from(prefix) + &rename_by_rule(&self.name, rule.as_str())
         } else {
             String::from(prefix) + &self.name
@@ -56,7 +57,8 @@ impl Command {
         } else {
             "/"
         };
-        if let Some(rule) = &global_parameters.rename_rule {
+        if global_parameters.rename_rule.is_some() && !self.renamed {
+            let rule = global_parameters.rename_rule.as_ref().unwrap();
             (String::from(prefix), rename_by_rule(&self.name, rule.as_str()))
         } else {
             (String::from(prefix), self.name.clone())

--- a/src/rename_rules.rs
+++ b/src/rename_rules.rs
@@ -21,7 +21,7 @@ pub fn rename_by_rule(input: &str, rule: &str) -> String {
         "SCREAMING_SNAKE_CASE" => input.to_shouty_snake_case(),
         "kebab-case" => input.to_kebab_case(),
         "SCREAMING-KEBAB-CASE" => input.to_shouty_kebab_case(),
-        _ => input.to_string(),
+        data => data.to_string(),
     }
 }
 


### PR DESCRIPTION
Hi,

I created a pr to fix an issue with rename tag on a particular enum type.
Unfortunately, the current state doesn't allow you to rename a command and forces you to use the enum name as a command.

Resolves https://github.com/teloxide/teloxide/issues/584
