### PR TITLE
Allow specifying a path to a command handler in `parse_with`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+### Fixed
+
+ - Allow specifying a path to a command handler in `parse_with` ([PR #27](https://github.com/teloxide/teloxide-macros/pull/27)).
+
 ## 0.6.2 - 2022-05-27
 
 ### Fixed

--- a/src/fields_parse.rs
+++ b/src/fields_parse.rs
@@ -1,6 +1,6 @@
 extern crate quote;
 
-use quote::{__private::Span, quote, ToTokens};
+use quote::{quote, ToTokens};
 use syn::{FieldsNamed, FieldsUnnamed, Type};
 
 #[derive(Debug)]
@@ -89,8 +89,10 @@ fn create_parser<'a>(
             count_args,
         ),
         ParserType::Custom(s) => {
-            let ident = syn::Ident::new(s, Span::call_site());
-            quote! { #ident }
+            let path = syn::parse_str::<syn::Path>(s).expect(&format!(
+                "Failed to parse a custom command parser, {s}"
+            ));
+            quote! { #path }
         }
     };
     quote! {

--- a/src/fields_parse.rs
+++ b/src/fields_parse.rs
@@ -89,9 +89,9 @@ fn create_parser<'a>(
             count_args,
         ),
         ParserType::Custom(s) => {
-            let path = syn::parse_str::<syn::Path>(s).expect(&format!(
-                "Failed to parse a custom command parser, {s}"
-            ));
+            let path = syn::parse_str::<syn::Path>(s).unwrap_or_else(|_| {
+                panic!("Failed to parse a custom command parser, {}", s)
+            });
             quote! { #path }
         }
     };


### PR DESCRIPTION
Resolves https://github.com/teloxide/teloxide/issues/668.