### PR TITLE
Enable command documentation with `///` (doc attr)

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -26,8 +26,8 @@ impl Parse for BotCommandAttribute {
 }
 
 pub struct Attr {
-    name: BotCommandAttribute,
-    value: String,
+    pub name: BotCommandAttribute,
+    pub value: String,
 }
 
 impl Parse for Attr {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,6 @@ pub fn derive_telegram_command_enum(tokens: TokenStream) -> TokenStream {
                         attrs.append(attrs_.data.as_mut());
                     }
                     Err(e) => {
-                        dbg!(&e);
                         return compile_error(e.to_compile_error());
                     }
                 }
@@ -278,7 +277,7 @@ fn process_doc_comment(lines: Vec<String>) -> String {
         }
     }
 
-    lines.join("/n")
+    lines.join("\n")
 }
 
 fn is_blank(s: &str) -> bool {


### PR DESCRIPTION
Enable documentation of bot commands via doc attr (the compiler converts `/// ...` to doc attr) This pr follows https://github.com/teloxide/teloxide/issues/635