### PR TITLE
Remove the `authors` field from `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 name = "teloxide-macros"
 version = "0.6.3"
 description = "The teloxide's procedural macros"
-authors = ["p0lunin <dmytro.polunin@gmail.com>"]
 license = "MIT"
 edition = "2018"
 


### PR DESCRIPTION
For rationale, see https://github.com/teloxide/teloxide-core/pull/148#issuecomment-998751346