### PR TITLE
Proper rename functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `#[command(rename = "a_name_that_is_not_a_case_name")]` doesn't work anymore
+- `#[command(rename = "...")]` now always renames to `"..."`, to rename multiple commands using the same pattern, use `#[command(rename_rule = "snake_case")]` and the like.
 
 ## 0.6.3 - 2022-07-19
 

--- a/src/command_attr.rs
+++ b/src/command_attr.rs
@@ -14,6 +14,7 @@ pub(crate) struct CommandAttrs {
     pub prefix: Option<(String, Span)>,
     pub description: Option<(String, Span)>,
     pub rename_rule: Option<(RenameRule, Span)>,
+    pub rename: Option<(String, Span)>,
     pub parser: Option<(ParserType, Span)>,
     pub separator: Option<(String, Span)>,
 }
@@ -37,6 +38,7 @@ enum CommandAttrKind {
     Prefix(String),
     Description(String),
     RenameRule(RenameRule),
+    Rename(String),
     ParseWith(ParserType),
     Separator(String),
 }
@@ -53,6 +55,7 @@ impl CommandAttrs {
                 prefix: None,
                 description: None,
                 rename_rule: None,
+                rename: None,
                 parser: None,
                 separator: None,
             },
@@ -77,6 +80,7 @@ impl CommandAttrs {
                     Prefix(p) => insert(&mut this.prefix, p, attr.sp),
                     Description(d) => insert(&mut this.description, d, attr.sp),
                     RenameRule(r) => insert(&mut this.rename_rule, r, attr.sp),
+                    Rename(r) => insert(&mut this.rename, r, attr.sp),
                     ParseWith(p) => insert(&mut this.parser, p, attr.sp),
                     Separator(s) => insert(&mut this.separator, s, attr.sp),
                 }?;
@@ -101,6 +105,7 @@ impl CommandAttr {
                     .expect_string()
                     .and_then(|r| self::RenameRule::parse(&r))?,
             ),
+            "rename" => Rename(value.expect_string()?),
             "parse_with" => {
                 ParseWith(value.expect_string().map(|p| ParserType::parse(&p))?)
             }

--- a/src/command_attr.rs
+++ b/src/command_attr.rs
@@ -27,7 +27,7 @@ pub(crate) struct CommandAttr {
 pub(crate) enum CommandAttrKind {
     Prefix(String),
     Description(String),
-    Rename(RenameRule),
+    RenameRule(RenameRule),
     ParseWith(ParserType),
     Separator(String),
 }
@@ -67,7 +67,7 @@ impl CommandAttrs {
                 match attr.kind {
                     Prefix(p) => insert(&mut this.prefix, p, attr.sp),
                     Description(d) => insert(&mut this.description, d, attr.sp),
-                    Rename(r) => insert(&mut this.rename_rule, r, attr.sp),
+                    RenameRule(r) => insert(&mut this.rename_rule, r, attr.sp),
                     ParseWith(p) => insert(&mut this.parser, p, attr.sp),
                     Separator(s) => insert(&mut this.separator, s, attr.sp),
                 }?;
@@ -87,8 +87,10 @@ impl CommandAttr {
         let kind = match &*key.to_string() {
             "prefix" => Prefix(value.expect_string()?),
             "description" => Description(value.expect_string()?),
-            "rename" => Rename(
-                value.expect_string().and_then(|r| RenameRule::parse(&r))?,
+            "rename_rule" => RenameRule(
+                value
+                    .expect_string()
+                    .and_then(|r| self::RenameRule::parse(&r))?,
             ),
             "parse_with" => {
                 ParseWith(value.expect_string().map(|p| ParserType::parse(&p))?)

--- a/src/command_enum.rs
+++ b/src/command_enum.rs
@@ -5,14 +5,15 @@ use crate::{
 
 #[derive(Debug)]
 pub(crate) struct CommandEnum {
-    pub prefix: Option<String>,
+    pub prefix: String,
     pub description: Option<String>,
     pub rename_rule: RenameRule,
     pub parser_type: ParserType,
 }
 
 impl CommandEnum {
-    pub fn try_from(attrs: CommandAttrs) -> Result<Self> {
+    pub fn from_attributes(attributes: &[syn::Attribute]) -> Result<Self> {
+        let attrs = CommandAttrs::from_attributes(attributes)?;
         let CommandAttrs {
             prefix,
             description,
@@ -20,18 +21,22 @@ impl CommandEnum {
             parser,
             separator,
         } = attrs;
-        let mut parser = parser.unwrap_or(ParserType::Default);
+
+        let mut parser = parser.map(|(p, _)| p).unwrap_or(ParserType::Default);
 
         // FIXME: Error on unused separator
-        if let (ParserType::Split { separator }, Some(s)) =
+        if let (ParserType::Split { separator }, Some((s, _))) =
             (&mut parser, &separator)
         {
             *separator = Some(s.clone())
         }
+
         Ok(Self {
-            prefix,
-            description,
-            rename_rule: rename_rule.unwrap_or(RenameRule::Identity),
+            prefix: prefix.map(|(p, _)| p).unwrap_or_else(|| "/".to_owned()),
+            description: description.map(|(d, _)| d),
+            rename_rule: rename_rule
+                .map(|(rr, _)| rr)
+                .unwrap_or(RenameRule::Identity),
             parser_type: parser,
         })
     }

--- a/src/command_enum.rs
+++ b/src/command_enum.rs
@@ -1,6 +1,6 @@
 use crate::{
-    command_attr::CommandAttrs, fields_parse::ParserType,
-    rename_rules::RenameRule, Result,
+    command_attr::CommandAttrs, error::compile_error_at,
+    fields_parse::ParserType, rename_rules::RenameRule, Result,
 };
 
 #[derive(Debug)]
@@ -18,9 +18,17 @@ impl CommandEnum {
             prefix,
             description,
             rename_rule,
+            rename,
             parser,
             separator,
         } = attrs;
+
+        if let Some((_rename, sp)) = rename {
+            return Err(compile_error_at(
+                "`rename` attribute can only be applied to enums *variants*",
+                sp,
+            ));
+        }
 
         let mut parser = parser.map(|(p, _)| p).unwrap_or(ParserType::Default);
 

--- a/src/fields_parse.rs
+++ b/src/fields_parse.rs
@@ -1,7 +1,7 @@
 use quote::quote;
 use syn::{Fields, FieldsNamed, FieldsUnnamed, Type};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) enum ParserType {
     Default,
     Split { separator: Option<String> },

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -249,8 +249,8 @@ fn rename_rules() {
         GggGgg,
         #[command(rename_rule = "SCREAMING-KEBAB-CASE")]
         HhhHhh,
-        //#[command(rename = "Bar")]
-        //Foo,
+        #[command(rename = "Bar")]
+        Foo,
     }
 
     assert_eq!(
@@ -285,16 +285,14 @@ fn rename_rules() {
         DefaultCommands::HhhHhh,
         DefaultCommands::parse("/HHH-HHH", "").unwrap()
     );
-    //assert_eq!(DefaultCommands::Foo, DefaultCommands::parse("/Bar",
-    // "").unwrap());
+    assert_eq!(
+        DefaultCommands::Foo,
+        DefaultCommands::parse("/Bar", "").unwrap()
+    );
 
-    // assert_eq!(
-    //     "/aaaaaa\n/BBBBBB\n/CccCcc\n/dddDdd\n/eee_eee\n/FFF_FFF\n/ggg-ggg\n/
-    // HHH-HHH\n/Bar",     DefaultCommands::descriptions().to_string()
-    // );
     assert_eq!(
         "/aaaaaa\n/BBBBBB\n/CccCcc\n/dddDdd\n/eee_eee\n/FFF_FFF\n/ggg-ggg\n/\
-         HHH-HHH",
+         HHH-HHH\n/Bar",
         DefaultCommands::descriptions().to_string()
     );
 }

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -9,7 +9,7 @@ use teloxide::utils::command::BotCommands as _;
 #[test]
 fn parse_command_with_args() {
     #[derive(BotCommands, Debug, PartialEq)]
-    #[command(rename = "lowercase")]
+    #[command(rename_rule = "lowercase")]
     enum DefaultCommands {
         Start(String),
         Help,
@@ -24,7 +24,7 @@ fn parse_command_with_args() {
 #[test]
 fn parse_command_with_non_string_arg() {
     #[derive(BotCommands, Debug, PartialEq)]
-    #[command(rename = "lowercase")]
+    #[command(rename_rule = "lowercase")]
     enum DefaultCommands {
         Start(i32),
         Help,
@@ -39,7 +39,7 @@ fn parse_command_with_non_string_arg() {
 #[test]
 fn attribute_prefix() {
     #[derive(BotCommands, Debug, PartialEq)]
-    #[command(rename = "lowercase")]
+    #[command(rename_rule = "lowercase")]
     enum DefaultCommands {
         #[command(prefix = "!")]
         Start(String),
@@ -55,7 +55,7 @@ fn attribute_prefix() {
 #[test]
 fn many_attributes() {
     #[derive(BotCommands, Debug, PartialEq)]
-    #[command(rename = "lowercase")]
+    #[command(rename_rule = "lowercase")]
     enum DefaultCommands {
         #[command(prefix = "!", description = "desc")]
         Start,
@@ -75,7 +75,11 @@ fn many_attributes() {
 #[test]
 fn global_attributes() {
     #[derive(BotCommands, Debug, PartialEq)]
-    #[command(prefix = "!", rename = "lowercase", description = "Bot commands")]
+    #[command(
+        prefix = "!",
+        rename_rule = "lowercase",
+        description = "Bot commands"
+    )]
     enum DefaultCommands {
         #[command(prefix = "/")]
         Start,
@@ -99,7 +103,7 @@ fn global_attributes() {
 #[test]
 fn parse_command_with_bot_name() {
     #[derive(BotCommands, Debug, PartialEq)]
-    #[command(rename = "lowercase")]
+    #[command(rename_rule = "lowercase")]
     enum DefaultCommands {
         #[command(prefix = "/")]
         Start,
@@ -115,7 +119,7 @@ fn parse_command_with_bot_name() {
 #[test]
 fn parse_with_split() {
     #[derive(BotCommands, Debug, PartialEq)]
-    #[command(rename = "lowercase")]
+    #[command(rename_rule = "lowercase")]
     #[command(parse_with = "split")]
     enum DefaultCommands {
         Start(u8, String),
@@ -131,7 +135,7 @@ fn parse_with_split() {
 #[test]
 fn parse_with_split2() {
     #[derive(BotCommands, Debug, PartialEq)]
-    #[command(rename = "lowercase")]
+    #[command(rename_rule = "lowercase")]
     #[command(parse_with = "split", separator = "|")]
     enum DefaultCommands {
         Start(u8, String),
@@ -174,7 +178,7 @@ fn parse_custom_parser() {
     use parser::custom_parse_function;
 
     #[derive(BotCommands, Debug, PartialEq)]
-    #[command(rename = "lowercase")]
+    #[command(rename_rule = "lowercase")]
     enum DefaultCommands {
         #[command(parse_with = "custom_parse_function")]
         Start(u8, String),
@@ -199,7 +203,7 @@ fn parse_custom_parser() {
 #[test]
 fn parse_named_fields() {
     #[derive(BotCommands, Debug, PartialEq)]
-    #[command(rename = "lowercase")]
+    #[command(rename_rule = "lowercase")]
     #[command(parse_with = "split")]
     enum DefaultCommands {
         Start { num: u8, data: String },
@@ -215,7 +219,7 @@ fn parse_named_fields() {
 #[test]
 fn descriptions_off() {
     #[derive(BotCommands, Debug, PartialEq)]
-    #[command(rename = "lowercase")]
+    #[command(rename_rule = "lowercase")]
     enum DefaultCommands {
         #[command(description = "off")]
         Start,
@@ -229,21 +233,21 @@ fn descriptions_off() {
 fn rename_rules() {
     #[derive(BotCommands, Debug, PartialEq)]
     enum DefaultCommands {
-        #[command(rename = "lowercase")]
+        #[command(rename_rule = "lowercase")]
         AaaAaa,
-        #[command(rename = "UPPERCASE")]
+        #[command(rename_rule = "UPPERCASE")]
         BbbBbb,
-        #[command(rename = "PascalCase")]
+        #[command(rename_rule = "PascalCase")]
         CccCcc,
-        #[command(rename = "camelCase")]
+        #[command(rename_rule = "camelCase")]
         DddDdd,
-        #[command(rename = "snake_case")]
+        #[command(rename_rule = "snake_case")]
         EeeEee,
-        #[command(rename = "SCREAMING_SNAKE_CASE")]
+        #[command(rename_rule = "SCREAMING_SNAKE_CASE")]
         FffFff,
-        #[command(rename = "kebab-case")]
+        #[command(rename_rule = "kebab-case")]
         GggGgg,
-        #[command(rename = "SCREAMING-KEBAB-CASE")]
+        #[command(rename_rule = "SCREAMING-KEBAB-CASE")]
         HhhHhh,
         //#[command(rename = "Bar")]
         //Foo,


### PR DESCRIPTION
To rename to a certain case, you now need to use `rename_rule`, to rename to a specific string you need to use `rename`.