### PR TITLE
Parse path instead of string when parsing `parse_with`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `#[command(rename = "...")]` now always renames to `"..."`, to rename multiple commands using the same pattern, use `#[command(rename_rule = "snake_case")]` and the like.
+- `#[command(parse_with = ...)]` now requires a path, instead of a string, when specifying custom parsers
 
 ## 0.6.3 - 2022-07-19
 

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -99,7 +99,7 @@ impl AttrValue {
     //     })
     // }
 
-    fn expect<T>(
+    pub fn expect<T>(
         self,
         expected: &str,
         f: impl FnOnce(Self) -> Result<T, Self>,

--- a/src/command_attr.rs
+++ b/src/command_attr.rs
@@ -106,9 +106,7 @@ impl CommandAttr {
                     .and_then(|r| self::RenameRule::parse(&r))?,
             ),
             "rename" => Rename(value.expect_string()?),
-            "parse_with" => {
-                ParseWith(value.expect_string().map(|p| ParserType::parse(&p))?)
-            }
+            "parse_with" => ParseWith(ParserType::parse(value)?),
             "separator" => Separator(value.expect_string()?),
             _ => {
                 return Err(compile_error_at(

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -180,11 +180,11 @@ fn parse_custom_parser() {
     #[derive(BotCommands, Debug, PartialEq)]
     #[command(rename_rule = "lowercase")]
     enum DefaultCommands {
-        #[command(parse_with = "custom_parse_function")]
+        #[command(parse_with = custom_parse_function)]
         Start(u8, String),
 
         // Test <https://github.com/teloxide/teloxide/issues/668>.
-        #[command(parse_with = "parser::custom_parse_function")]
+        #[command(parse_with = parser::custom_parse_function)]
         TestPath(u8, String),
 
         Help,


### PR DESCRIPTION
No more paths in a trench coat!

But more importantly this fixes the ambiguity between `"split"` (built-in parser) and `"split"` (function in the current module). Now you'd write `"split"` for built-in and `split` for a function.