### PR TITLE
Enhance an error message about a path

### DIFF
--- a/src/fields_parse.rs
+++ b/src/fields_parse.rs
@@ -12,15 +12,18 @@ pub(crate) enum ParserType {
 
 impl ParserType {
     pub fn parse(value: AttrValue) -> Result<Self> {
-        value.expect(r#""default", "split" or a path"#, |v| match v {
-            AttrValue::Path(p) => Ok(ParserType::Custom(p)),
-            AttrValue::Lit(syn::Lit::Str(ref l)) => match &*l.value() {
-                "default" => Ok(ParserType::Default),
-                "split" => Ok(ParserType::Split { separator: None }),
+        value.expect(
+            r#""default", "split", or a path for custom parsers"#,
+            |v| match v {
+                AttrValue::Path(p) => Ok(ParserType::Custom(p)),
+                AttrValue::Lit(syn::Lit::Str(ref l)) => match &*l.value() {
+                    "default" => Ok(ParserType::Default),
+                    "split" => Ok(ParserType::Split { separator: None }),
+                    _ => Err(v),
+                },
                 _ => Err(v),
             },
-            _ => Err(v),
-        })
+        )
     }
 }
 


### PR DESCRIPTION
Since we break BC by this change, it's helpful for our users that custom parsers are now specified by a path.