### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## unreleased
 
+## 0.7.0 - 2022-10-06
+
 ### Removed
 
-- Remove `derive(DialogueState)` macro
+- `derive(DialogueState)` macro
 
 ### Changed
 
-- `#[command(rename = "...")]` now always renames to `"..."`, to rename multiple commands using the same pattern, use `#[command(rename_rule = "snake_case")]` and the like.
-- `#[command(parse_with = ...)]` now requires a path, instead of a string, when specifying custom parsers
+- `#[command(rename = "...")]` now always renames to `"..."`; to rename multiple commands using the same pattern, use `#[command(rename_rule = "snake_case")]` and the like.
+- `#[command(parse_with = ...)]` now requires a path, instead of a string, when specifying custom parsers.
+
+### Fixed
+
+- `#[derive(BotCommands)]` even if the trait is not imported ([issue #717](https://github.com/teloxide/teloxide/issues/717)).
 
 ## 0.6.3 - 2022-07-19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "teloxide-macros"
 version = "0.7.0"
 description = "The teloxide's procedural macros"
 license = "MIT"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teloxide-macros"
-version = "0.6.3"
+version = "0.7.0"
 description = "The teloxide's procedural macros"
 license = "MIT"
 edition = "2018"

--- a/src/command_enum.rs
+++ b/src/command_enum.rs
@@ -3,7 +3,6 @@ use crate::{
     fields_parse::ParserType, rename_rules::RenameRule, Result,
 };
 
-#[derive(Debug)]
 pub(crate) struct CommandEnum {
     pub prefix: String,
     pub description: Option<String>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,8 +17,6 @@ pub(crate) fn compile_error_at(msg: &str, sp: Span) -> Error {
     use proc_macro2::{
         Delimiter, Group, Ident, Literal, Punct, Spacing, TokenTree,
     };
-    use std::iter::FromIterator;
-
     // compile_error! { $msg }
     let ts = TokenStream::from_iter(vec![
         TokenTree::Ident(Ident::new("compile_error", sp)),

--- a/src/fields_parse.rs
+++ b/src/fields_parse.rs
@@ -3,7 +3,7 @@ use syn::{Fields, FieldsNamed, FieldsUnnamed, Type};
 
 use crate::{attr::AttrValue, error::Result};
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) enum ParserType {
     Default,
     Split { separator: Option<String> },


### PR DESCRIPTION
For some reason, `cargo publish --dry-run --allow-dirty` doesn't work:

```
$ cargo publish --dry-run --allow-dirty
    Blocking waiting for file lock on package cache
    Updating crates.io index
warning: manifest has no documentation, homepage or repository.
See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
   Packaging teloxide-macros v0.7.0 (/home/hirrolot/Desktop/teloxide-macros)
   Verifying teloxide-macros v0.7.0 (/home/hirrolot/Desktop/teloxide-macros)
   Compiling proc-macro2 v1.0.46
   Compiling quote v1.0.21
   Compiling unicode-ident v1.0.4
   Compiling syn v1.0.101
   Compiling heck v0.4.0
   Compiling teloxide-macros v0.7.0 (/home/hirrolot/Desktop/teloxide-macros/target/package/teloxide-macros-0.7.0)
error[E0277]: `syn::Path` doesn't implement `Debug`
  --> src/fields_parse.rs:10:12
   |
6  | #[derive(Debug, Clone)]
   |          ----- in this derive macro expansion
...
10 |     Custom(syn::Path),
   |            ^^^^^^^^^ `syn::Path` cannot be formatted using `{:?}` because it doesn't implement `Debug`
   |
   = help: the trait `Debug` is not implemented for `syn::Path`
   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0277`.
error: could not compile `teloxide-macros` due to previous error
```

While `cargo check` works perfectly.
