### PR TITLE
Add a warning to `README.md` about repository status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+> **Warning**
+> 
+> This repository used to contain source code for [`teloxide-macros`] crate.
+> We've later decided to move everything into a single repository, namely [`teloxide/teloxide`], to ease development/maintaining process.
+> To file issues, make PRs or view current developments go to [`teloxide/teloxide`] repository.
+> 
+> [`teloxide-macros`]: https://lib.rs/crates/teloxide-macros
+> [`teloxide/teloxide`]: https://github.com/teloxide/teloxide

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 > **Warning**
 > 
-> This repository used to contain source code for [`teloxide-macros`] crate.
-> We've later decided to move everything into a single repository, namely [`teloxide/teloxide`], to ease development/maintaining process.
-> To file issues, make PRs or view current developments go to [`teloxide/teloxide`] repository.
+> This repository used to contain source code for the [`teloxide-macros`] crate.
+> We've later decided to move everything into a single repository, namely [`teloxide/teloxide`], to ease the development/maintenance process.
+> To file issues, make PRs, or view current developments, go to the [`teloxide/teloxide`] repository.
 > 
 > [`teloxide-macros`]: https://lib.rs/crates/teloxide-macros
 > [`teloxide/teloxide`]: https://github.com/teloxide/teloxide


### PR DESCRIPTION
Since we've [merged](https://github.com/teloxide/teloxide/pull/759) this repo into `teloxide`, we should archive this repository.